### PR TITLE
Address additional review comments regarding port-speed and switch ca…

### DIFF
--- a/translib/transformer/xfmr_intf.go
+++ b/translib/transformer/xfmr_intf.go
@@ -126,6 +126,7 @@ var intfOCToSpeedMap = map[ocbinds.E_OpenconfigIfEthernet_ETHERNET_SPEED]string{
 	ocbinds.OpenconfigIfEthernet_ETHERNET_SPEED_SPEED_100GB:  "100000",
 	ocbinds.OpenconfigIfEthernet_ETHERNET_SPEED_SPEED_200GB:  "200000",
 	ocbinds.OpenconfigIfEthernet_ETHERNET_SPEED_SPEED_400GB:  "400000",
+	ocbinds.OpenconfigIfEthernet_ETHERNET_SPEED_SPEED_800GB:  "800000",
 }
 
 type E_InterfaceType int64
@@ -159,17 +160,13 @@ func getIntfsRoot(s *ygot.GoStruct) *ocbinds.OpenconfigInterfaces_Interfaces {
 
 func getPortTableNameByDBId(intftbl IntfTblData, curDb db.DBNum) (string, error) {
 
-	var tblName string
+	tblName := intftbl.cfgDb.portTN
 
 	switch curDb {
-	case db.ConfigDB:
-		tblName = intftbl.cfgDb.portTN
 	case db.ApplDB:
 		tblName = intftbl.appDb.portTN
 	case db.StateDB:
 		tblName = intftbl.stateDb.portTN
-	default:
-		tblName = intftbl.cfgDb.portTN
 	}
 
 	return tblName, nil


### PR DESCRIPTION
…se formatting

[feb28_TESTAPP.log](https://github.com/nagarwal03/oc-yang-intf/files/14440648/feb28_testapp.log)
[feb28_TRANSLIB.log](https://github.com/nagarwal03/oc-yang-intf/files/14440650/feb28_translib.log)

CURL output for 800GB Speed to ensure it is added.

satoru@satoru-virtual-machine:~/sonic_jan25_common/sonic-buildimage$ curl -kX PATCH
 "https://100.94.113.103/restconf/data/openconfig-interfaces:interfaces/interface=Ethernet104/openconfig-if-ethernet:ethernet/config/port-speed" -H "accept: */*" -H "Content-Type: application/yang-data+json" -d "{\"openconfig-if-ethernet:port-speed\":\"SPEED_800GB\"}"


satoru@satoru-virtual-machine:~/sonic_jan25_common/sonic-buildimage$ curl -kX GET "https://100.94.113.103/restconf/data/openconfig-interfaces:interfaces/interface=Ethernet104/openconfig-if-ethernet:ethernet/config/port-speed" -H "accept: application/yang-data+json"{"openconfig-if-ethernet:port-speed":"openconfig-if-ethernet:SPEED_800GB"}


satoru@satoru-virtual-machine:~/sonic_jan25_common/sonic-buildimage$ curl -kX GET"https://100.94.113.103/restconf/data/openconfig-interfaces:interfaces/interface=Ethernet104/openconfig-if-ethernet:ethernet/state/port-speed" -H "accept: application/yang-data+json"{"openconfig-if-ethernet:port-speed":"openconfig-if-ethernet:SPEED_800GB"}
