### PR TITLE
Add logs for CONFIG_DB to test lane errors on azure-pipelines

### DIFF
--- a/translib/transformer/interfaces_openconfig_test.go
+++ b/translib/transformer/interfaces_openconfig_test.go
@@ -23,12 +23,22 @@ package transformer_test
 
 import (
 	"github.com/Azure/sonic-mgmt-common/translib/tlerr"
+	"os/exec"
 	"testing"
 	"time"
 )
 
 func Test_openconfig_interfaces(t *testing.T) {
 	var url, url_input_body_json string
+
+	cmd := exec.Command("sonic-db-dump", "-y", "-n", "CONFIG_DB", "-k", "\"PORT|*\"")
+
+	out, err := cmd.Output()
+	if err != nil {
+		t.Log("DB Dump command failed")
+	}
+
+	t.Log(string(out))
 
 	t.Log("\n\n+++++++++++++ CONFIGURING INTERFACES ATTRIBUTES ++++++++++++")
 	t.Log("\n\n--- PATCH interfaces config---")


### PR DESCRIPTION
Error seen: 

> [CVL] : ValidateEditConfig() failed: ErrCode[1003]: ErrDetails[Required Field is Missing], Msg[Field "lanes" has invalid value], ConstraintErrMsg[], Table[PORT:[Ethernet0]], Field[lanes:]

Log added: 

```
          "PORT|Ethernet0": {
            "expireat": 1710278491.267493,
            "ttl": -0.001,
            "type": "hash",
            "value": {
              "admin_status": "down",
              "alias": "hundredGigE1/1",
              "autoneg": "off",
              "description": "UT_Interface",
              "index": "1",
              "lanes": "49,50,51,52",
              "mtu": "8900",
              "speed": "10000"
            }
          },
          "PORT|Ethernet100": {
            "expireat": 1710278491.3674924,
            "ttl": -0.001,
            "type": "hash",
            "value": {
              "admin_status": "up",
              "alias": "hundredGigE1/26",
              "index": "26",
              "lanes": "145,146,147,148",
              "mtu": "9100",
              "speed": "100000"
            }
          },
```