### PR TITLE
interface and ethernet counters REST GET support

### DIFF
--- a/models/yang/annotations/openconfig-interfaces-annot.yang
+++ b/models/yang/annotations/openconfig-interfaces-annot.yang
@@ -75,6 +75,22 @@ module openconfig-interfaces-annot {
             sonic-ext:field-name "admin_status";
         }
     }
+
+    deviation /oc-intf:interfaces/oc-intf:interface/oc-intf:state/oc-intf:counters {
+        deviate add {
+            sonic-ext:subtree-transformer "intf_get_counters_xfmr";
+            sonic-ext:db-name "COUNTERS_DB";
+            sonic-ext:subscribe-on-change "disable";
+        }
+    }
+
+    deviation /oc-intf:interfaces/oc-intf:interface/oc-eth:ethernet/oc-eth:state/oc-eth:counters {
+        deviate add {
+            sonic-ext:db-name "COUNTERS_DB";
+            sonic-ext:subtree-transformer "intf_get_ether_counters_xfmr";
+            sonic-ext:subscribe-on-change "disable";
+        }
+    }
     
     deviation /oc-intf:interfaces {
       deviate add {

--- a/models/yang/extensions/openconfig-interfaces-deviation.yang
+++ b/models/yang/extensions/openconfig-interfaces-deviation.yang
@@ -55,11 +55,7 @@ module openconfig-interfaces-deviation {
 
   deviation /oc-intf:interfaces/oc-intf:interface/oc-intf:state/oc-intf:last-change {
     deviate not-supported;
-  }    
-
-  deviation /oc-intf:interfaces/oc-intf:interface/oc-intf:state/oc-intf:counters {
-    deviate not-supported;
-  }    
+  }       
 
   deviation /oc-intf:interfaces/oc-intf:interface/oc-intf:state/oc-intf:type {
     deviate not-supported;
@@ -76,6 +72,22 @@ module openconfig-interfaces-deviation {
   deviation /oc-intf:interfaces/oc-intf:interface/oc-intf:state/oc-vlan:tpid {
     deviate not-supported;
   }   
+
+  deviation /oc-intf:interfaces/oc-intf:interface/oc-intf:state/oc-intf:counters/oc-intf:in-unknown-protos {
+    deviate not-supported;
+  }   
+  
+  deviation /oc-intf:interfaces/oc-intf:interface/oc-intf:state/oc-intf:counters/oc-intf:in-fcs-errors {
+    deviate not-supported;
+  }   
+
+  deviation /oc-intf:interfaces/oc-intf:interface/oc-intf:state/oc-intf:counters/oc-intf:carrier-transitions {
+    deviate not-supported;
+  }
+
+  deviation /oc-intf:interfaces/oc-intf:interface/oc-intf:state/oc-intf:counters/oc-intf:last-clear {
+    deviate not-supported;
+  }
 
   deviation /oc-intf:interfaces/oc-intf:interface/oc-intf:hold-time {
     deviate not-supported;
@@ -227,10 +239,6 @@ module openconfig-interfaces-deviation {
     deviate not-supported;
   }
 
-  deviation /oc-intf:interfaces/oc-intf:interface/oc-eth:ethernet/oc-eth:state/oc-eth:counters {
-    deviate not-supported;
-  }
-
   deviation /oc-intf:interfaces/oc-intf:interface/oc-eth:ethernet/oc-eth:state/oc-lag:aggregate-id {
     deviate not-supported;
   }
@@ -244,6 +252,38 @@ module openconfig-interfaces-deviation {
   }
 
   deviation /oc-intf:interfaces/oc-intf:interface/oc-eth:ethernet/oc-eth:state/oc-eth:negotiated-port-speed {
+    deviate not-supported;
+  }
+
+  deviation /oc-intf:interfaces/oc-intf:interface/oc-eth:ethernet/oc-eth:state/oc-eth:counters/oc-eth:in-mac-control-frames {
+    deviate not-supported;
+  }
+
+  deviation /oc-intf:interfaces/oc-intf:interface/oc-eth:ethernet/oc-eth:state/oc-eth:counters/oc-eth:in-mac-pause-frames {
+    deviate not-supported;
+  }
+
+  deviation /oc-intf:interfaces/oc-intf:interface/oc-eth:ethernet/oc-eth:state/oc-eth:counters/oc-eth:in-8021q-frames {
+    deviate not-supported;
+  }
+
+  deviation /oc-intf:interfaces/oc-intf:interface/oc-eth:ethernet/oc-eth:state/oc-eth:counters/oc-eth:in-crc-errors {
+    deviate not-supported;
+  }
+
+  deviation /oc-intf:interfaces/oc-intf:interface/oc-eth:ethernet/oc-eth:state/oc-eth:counters/oc-eth:in-block-errors {
+    deviate not-supported;
+  }
+
+  deviation /oc-intf:interfaces/oc-intf:interface/oc-eth:ethernet/oc-eth:state/oc-eth:counters/oc-eth:out-mac-control-frames {
+    deviate not-supported;
+  }
+
+  deviation /oc-intf:interfaces/oc-intf:interface/oc-eth:ethernet/oc-eth:state/oc-eth:counters/oc-eth:out-mac-pause-frames {
+    deviate not-supported;
+  }
+
+  deviation /oc-intf:interfaces/oc-intf:interface/oc-eth:ethernet/oc-eth:state/oc-eth:counters/oc-eth:out-8021q-frames {
     deviate not-supported;
   }
 

--- a/translib/transformer/interfaces_openconfig_test.go
+++ b/translib/transformer/interfaces_openconfig_test.go
@@ -67,7 +67,7 @@ func Test_openconfig_interfaces(t *testing.T) {
 
 	t.Log("\n\n--- Verify PATCH interface leaf nodes  ---")
 	url = "/openconfig-interfaces:interfaces/interface[name=Ethernet0]/state"
-	expected_get_json = "{\"openconfig-interfaces:state\": { \"admin-status\": \"UP\", \"enabled\": true, \"mtu\": 9000, \"name\": \"Ethernet0\"}}"
+	expected_get_json = "{\"openconfig-interfaces:state\": { \"admin-status\": \"UP\", \"counters\": {\"in-broadcast-pkts\": \"0\", \"in-discards\": \"0\", \"in-errors\": \"0\", \"in-multicast-pkts\": \"0\", \"in-octets\": \"0\", \"in-pkts\": \"0\", \"in-unicast-pkts\": \"0\", \"out-broadcast-pkts\": \"0\", \"out-discards\": \"0\", \"out-errors\": \"0\", \"out-multicast-pkts\": \"0\", \"out-octets\": \"0\", \"out-pkts\": \"0\", \"out-unicast-pkts\": \"0\"}, \"enabled\": true, \"mtu\": 9000, \"name\": \"Ethernet0\"}}"
 	t.Run("Test GET on interface state", processGetRequest(url, nil, expected_get_json, false))
 	time.Sleep(1 * time.Second)
 
@@ -125,7 +125,7 @@ func Test_openconfig_interfaces(t *testing.T) {
 
 	t.Log("\n\n--- Verify PATCH interface ---")
 	url = "/openconfig-interfaces:interfaces/interface[name=Ethernet0]/state"
-	expected_get_json = "{\"openconfig-interfaces:state\": { \"admin-status\": \"UP\", \"enabled\": true, \"mtu\": 9100, \"name\": \"Ethernet0\"}}"
+	expected_get_json = "{\"openconfig-interfaces:state\": { \"admin-status\": \"UP\", \"counters\": {\"in-broadcast-pkts\": \"0\", \"in-discards\": \"0\", \"in-errors\": \"0\", \"in-multicast-pkts\": \"0\", \"in-octets\": \"0\", \"in-pkts\": \"0\", \"in-unicast-pkts\": \"0\", \"out-broadcast-pkts\": \"0\", \"out-discards\": \"0\", \"out-errors\": \"0\", \"out-multicast-pkts\": \"0\", \"out-octets\": \"0\", \"out-pkts\": \"0\", \"out-unicast-pkts\": \"0\"}, \"enabled\": true, \"mtu\": 9100, \"name\": \"Ethernet0\"}}"
 	t.Run("Test GET on interface state", processGetRequest(url, nil, expected_get_json, false))
 	time.Sleep(1 * time.Second)
 
@@ -154,7 +154,7 @@ func Test_openconfig_ethernet(t *testing.T) {
 
 	t.Log("\n\n--- Verify PATCH ethernet ---")
 	url = "/openconfig-interfaces:interfaces/interface[name=Ethernet0]/openconfig-if-ethernet:ethernet"
-	expected_get_json := "{\"openconfig-if-ethernet:ethernet\": {\"config\": {\"auto-negotiate\": true,\"port-speed\": \"openconfig-if-ethernet:SPEED_40GB\"},\"state\": {\"auto-negotiate\": true,\"port-speed\": \"openconfig-if-ethernet:SPEED_40GB\"}}}"
+	expected_get_json := "{\"openconfig-if-ethernet:ethernet\": {\"config\": {\"auto-negotiate\": true, \"port-speed\": \"openconfig-if-ethernet:SPEED_40GB\"}, \"state\": {\"auto-negotiate\": true, \"counters\": {\"in-fragment-frames\": \"0\", \"in-jabber-frames\": \"0\", \"in-oversize-frames\": \"0\", \"in-undersize-frames\": \"0\", \"openconfig-if-ethernet-ext:in-distribution\": {\"in-frames-1024-1518-octets\": \"0\", \"in-frames-128-255-octets\": \"0\", \"in-frames-256-511-octets\": \"0\", \"in-frames-512-1023-octets\": \"0\", \"in-frames-64-octets\": \"0\", \"in-frames-65-127-octets\": \"0\"}}, \"port-speed\": \"openconfig-if-ethernet:SPEED_40GB\"}}}"
 	t.Run("Test GET on ethernet", processGetRequest(url, nil, expected_get_json, false))
 	time.Sleep(1 * time.Second)
 
@@ -172,7 +172,7 @@ func Test_openconfig_ethernet(t *testing.T) {
 
 	t.Log("\n\n--- Verify DELETE at ethernet container  ---")
 	url = "/openconfig-interfaces:interfaces/interface[name=Ethernet0]/openconfig-if-ethernet:ethernet/state"
-	expected_get_json = "{\"openconfig-if-ethernet:state\": {\"auto-negotiate\": true, \"port-speed\": \"openconfig-if-ethernet:SPEED_40GB\"}}"
+	expected_get_json = "{\"openconfig-if-ethernet:state\": {\"auto-negotiate\": true,  \"counters\": {\"in-fragment-frames\": \"0\", \"in-jabber-frames\": \"0\", \"in-oversize-frames\": \"0\", \"in-undersize-frames\": \"0\", \"openconfig-if-ethernet-ext:in-distribution\": {\"in-frames-1024-1518-octets\": \"0\", \"in-frames-128-255-octets\": \"0\", \"in-frames-256-511-octets\": \"0\", \"in-frames-512-1023-octets\": \"0\", \"in-frames-64-octets\": \"0\", \"in-frames-65-127-octets\": \"0\"}}, \"port-speed\": \"openconfig-if-ethernet:SPEED_40GB\"}}"
 	t.Run("Test GET on ethernet state", processGetRequest(url, nil, expected_get_json, false))
 	time.Sleep(1 * time.Second)
 

--- a/translib/transformer/xfmr_intf.go
+++ b/translib/transformer/xfmr_intf.go
@@ -50,6 +50,13 @@ func init() {
 	XlateFuncBind("DbToYang_intf_eth_auto_neg_xfmr", DbToYang_intf_eth_auto_neg_xfmr)
 	XlateFuncBind("DbToYang_intf_eth_port_speed_xfmr", DbToYang_intf_eth_port_speed_xfmr)
 
+	XlateFuncBind("DbToYang_intf_get_counters_xfmr", DbToYang_intf_get_counters_xfmr)
+	//XlateFuncBind("Subscribe_intf_get_counters_xfmr", Subscribe_intf_get_counters_xfmr)
+	//XlateFuncBind("DbToYangPath_intf_get_counters_path_xfmr", DbToYangPath_intf_get_counters_path_xfmr)
+
+	XlateFuncBind("DbToYang_intf_get_ether_counters_xfmr", DbToYang_intf_get_ether_counters_xfmr)
+	//XlateFuncBind("Subscribe_intf_get_ether_counters_xfmr", Subscribe_intf_get_ether_counters_xfmr)
+
 	XlateFuncBind("YangToDb_intf_subintfs_xfmr", YangToDb_intf_subintfs_xfmr)
 	XlateFuncBind("DbToYang_intf_subintfs_xfmr", DbToYang_intf_subintfs_xfmr)
 
@@ -93,17 +100,27 @@ type TblData struct {
 	keySep   string
 }
 
+type PopulateIntfCounters func(inParams XfmrParams, counters interface{}) error
+
+type CounterData struct {
+	OIDTN            string
+	CountersTN       string
+	PopulateCounters PopulateIntfCounters
+}
+
 type IntfTblData struct {
-	cfgDb   TblData
-	appDb   TblData
-	stateDb TblData
+	cfgDb       TblData
+	appDb       TblData
+	stateDb     TblData
+	CountersHdl CounterData
 }
 
 var IntfTypeTblMap = map[E_InterfaceType]IntfTblData{
 	IntfTypeEthernet: IntfTblData{
-		cfgDb:   TblData{portTN: "PORT", intfTN: "INTERFACE", keySep: PIPE},
-		appDb:   TblData{portTN: "PORT_TABLE", intfTN: "INTF_TABLE", keySep: COLON},
-		stateDb: TblData{portTN: "PORT_TABLE", intfTN: "INTERFACE_TABLE", keySep: PIPE},
+		cfgDb:       TblData{portTN: "PORT", intfTN: "INTERFACE", keySep: PIPE},
+		appDb:       TblData{portTN: "PORT_TABLE", intfTN: "INTF_TABLE", keySep: COLON},
+		stateDb:     TblData{portTN: "PORT_TABLE", intfTN: "INTERFACE_TABLE", keySep: PIPE},
+		CountersHdl: CounterData{OIDTN: "COUNTERS_PORT_NAME_MAP", CountersTN: "COUNTERS", PopulateCounters: populatePortCounters},
 	},
 }
 
@@ -309,6 +326,8 @@ var intf_table_xfmr TableXfmrFunc = func(inParams XfmrParams) ([]string, error) 
 		//Checking interface type at container level, if not Ethernet type return nil
 		return nil, nil
 
+	} else if strings.HasPrefix(targetUriPath, "/openconfig-interfaces:interfaces/interface/state/counters") {
+		tblList = append(tblList, "NONE")
 	} else if strings.HasPrefix(targetUriPath, "/openconfig-interfaces:interfaces/interface/state") ||
 		strings.HasPrefix(targetUriPath, "/openconfig-interfaces:interfaces/interface/ethernet/state") ||
 		strings.HasPrefix(targetUriPath, "/openconfig-interfaces:interfaces/interface/openconfig-if-ethernet:ethernet/state") {
@@ -840,6 +859,396 @@ var DbToYang_intf_eth_port_speed_xfmr FieldXfmrDbtoYang = func(inParams XfmrPara
 	}
 
 	return result, err
+}
+
+func getIntfCountersTblKey(d *db.DB, ifKey string) (string, error) {
+	var oid string
+
+	portOidCountrTblTs := &db.TableSpec{Name: "COUNTERS_PORT_NAME_MAP"}
+	ifCountInfo, err := d.GetMapAll(portOidCountrTblTs)
+	if err != nil {
+		log.Error("Port-OID (Counters) get for all the interfaces failed!")
+		return oid, err
+	}
+
+	if ifCountInfo.IsPopulated() {
+		_, ok := ifCountInfo.Field[ifKey]
+		if !ok {
+			err = errors.New("OID info not found from Counters DB for interface " + ifKey)
+		} else {
+			oid = ifCountInfo.Field[ifKey]
+		}
+	} else {
+		err = errors.New("Get for OID info from all the interfaces from Counters DB failed!")
+	}
+
+	return oid, err
+}
+
+func getCounters(entry *db.Value, entry_backup *db.Value, attr string, counter_val **uint64) error {
+
+	var ok bool = false
+	var err error
+	val1, ok := entry.Field[attr]
+	if !ok {
+		return errors.New("Attr " + attr + "doesn't exist in IF table Map!")
+	}
+	val2, ok := entry_backup.Field[attr]
+	if !ok {
+		return errors.New("Attr " + attr + "doesn't exist in IF backup table Map!")
+	}
+
+	if len(val1) > 0 {
+		v, _ := strconv.ParseUint(val1, 10, 64)
+		v_backup, _ := strconv.ParseUint(val2, 10, 64)
+		val := v - v_backup
+		*counter_val = &val
+		return nil
+	}
+	return err
+}
+
+var portCntList []string = []string{"in-octets", "in-unicast-pkts", "in-broadcast-pkts", "in-multicast-pkts",
+	"in-errors", "in-discards", "in-pkts", "out-octets", "out-unicast-pkts",
+	"out-broadcast-pkts", "out-multicast-pkts", "out-errors", "out-discards",
+	"out-pkts"}
+var etherCntList []string = []string{"in-oversize-frames", "in-undersize-frames", "in-jabber-frames", "in-fragment-frames", "in-distribution/in-frames-128-255-octets"}
+var etherCntInList []string = []string{"in-frames-64-octets", "in-frames-65-127-octets", "in-frames-128-255-octets",
+	"in-frames-256-511-octets", "in-frames-512-1023-octets", "in-frames-1024-1518-octets"}
+
+func getSpecificCounterAttr(targetUriPath string, entry *db.Value, entry_backup *db.Value, counter interface{}) (bool, error) {
+
+	var e error
+	var counter_val *ocbinds.OpenconfigInterfaces_Interfaces_Interface_State_Counters
+	var eth_counter_val *ocbinds.OpenconfigInterfaces_Interfaces_Interface_Ethernet_State_Counters
+
+	if strings.HasPrefix(targetUriPath, "/openconfig-interfaces:interfaces/interface/state/counters") {
+		counter_val = counter.(*ocbinds.OpenconfigInterfaces_Interfaces_Interface_State_Counters)
+	} else {
+		eth_counter_val = counter.(*ocbinds.OpenconfigInterfaces_Interfaces_Interface_Ethernet_State_Counters)
+	}
+
+	switch targetUriPath {
+	case "/openconfig-interfaces:interfaces/interface/state/counters/in-octets":
+		e = getCounters(entry, entry_backup, "SAI_PORT_STAT_IF_IN_OCTETS", &counter_val.InOctets)
+		return true, e
+
+	case "/openconfig-interfaces:interfaces/interface/state/counters/in-unicast-pkts":
+		e = getCounters(entry, entry_backup, "SAI_PORT_STAT_IF_IN_UCAST_PKTS", &counter_val.InUnicastPkts)
+		return true, e
+
+	case "/openconfig-interfaces:interfaces/interface/state/counters/in-broadcast-pkts":
+		e = getCounters(entry, entry_backup, "SAI_PORT_STAT_IF_IN_BROADCAST_PKTS", &counter_val.InBroadcastPkts)
+		return true, e
+
+	case "/openconfig-interfaces:interfaces/interface/state/counters/in-multicast-pkts":
+		e = getCounters(entry, entry_backup, "SAI_PORT_STAT_IF_IN_MULTICAST_PKTS", &counter_val.InMulticastPkts)
+		return true, e
+
+	case "/openconfig-interfaces:interfaces/interface/state/counters/in-errors":
+		e = getCounters(entry, entry_backup, "SAI_PORT_STAT_IF_IN_ERRORS", &counter_val.InErrors)
+		return true, e
+
+	case "/openconfig-interfaces:interfaces/interface/state/counters/in-discards":
+		e = getCounters(entry, entry_backup, "SAI_PORT_STAT_IF_IN_DISCARDS", &counter_val.InDiscards)
+		return true, e
+
+	case "/openconfig-interfaces:interfaces/interface/state/counters/in-pkts":
+		var inNonUCastPkt, inUCastPkt *uint64
+		var in_pkts uint64
+
+		e = getCounters(entry, entry_backup, "SAI_PORT_STAT_IF_IN_NON_UCAST_PKTS", &inNonUCastPkt)
+		if e == nil {
+			e = getCounters(entry, entry_backup, "SAI_PORT_STAT_IF_IN_UCAST_PKTS", &inUCastPkt)
+			if e != nil {
+				return true, e
+			}
+			in_pkts = *inUCastPkt + *inNonUCastPkt
+			counter_val.InPkts = &in_pkts
+			return true, e
+		} else {
+			return true, e
+		}
+
+	case "/openconfig-interfaces:interfaces/interface/state/counters/out-octets":
+		e = getCounters(entry, entry_backup, "SAI_PORT_STAT_IF_OUT_OCTETS", &counter_val.OutOctets)
+		return true, e
+
+	case "/openconfig-interfaces:interfaces/interface/state/counters/out-unicast-pkts":
+		e = getCounters(entry, entry_backup, "SAI_PORT_STAT_IF_OUT_UCAST_PKTS", &counter_val.OutUnicastPkts)
+		return true, e
+
+	case "/openconfig-interfaces:interfaces/interface/state/counters/out-broadcast-pkts":
+		e = getCounters(entry, entry_backup, "SAI_PORT_STAT_IF_OUT_BROADCAST_PKTS", &counter_val.OutBroadcastPkts)
+		return true, e
+
+	case "/openconfig-interfaces:interfaces/interface/state/counters/out-multicast-pkts":
+		e = getCounters(entry, entry_backup, "SAI_PORT_STAT_IF_OUT_MULTICAST_PKTS", &counter_val.OutMulticastPkts)
+		return true, e
+
+	case "/openconfig-interfaces:interfaces/interface/state/counters/out-errors":
+		e = getCounters(entry, entry_backup, "SAI_PORT_STAT_IF_OUT_ERRORS", &counter_val.OutErrors)
+		return true, e
+
+	case "/openconfig-interfaces:interfaces/interface/state/counters/out-discards":
+		e = getCounters(entry, entry_backup, "SAI_PORT_STAT_IF_OUT_DISCARDS", &counter_val.OutDiscards)
+		return true, e
+
+	//case "/openconfig-interfaces:interfaces/interface/state/counters/last-clear":
+	//	timestampStr := (entry_backup.Field["LAST_CLEAR_TIMESTAMP"])
+	//	timestamp, _ := strconv.ParseUint(timestampStr, 10, 64)
+	//	counter_val.LastClear = &timestamp
+	//	return true, e
+	//
+	case "/openconfig-interfaces:interfaces/interface/state/counters/out-pkts":
+		var outNonUCastPkt, outUCastPkt *uint64
+		var out_pkts uint64
+
+		e = getCounters(entry, entry_backup, "SAI_PORT_STAT_IF_OUT_NON_UCAST_PKTS", &outNonUCastPkt)
+		if e == nil {
+			e = getCounters(entry, entry_backup, "SAI_PORT_STAT_IF_OUT_UCAST_PKTS", &outUCastPkt)
+			if e != nil {
+				return true, e
+			}
+			out_pkts = *outUCastPkt + *outNonUCastPkt
+			counter_val.OutPkts = &out_pkts
+			return true, e
+		} else {
+			return true, e
+		}
+
+	case "/openconfig-interfaces:interfaces/interface/ethernet/state/counters/in-oversize-frames",
+		"/openconfig-interfaces:interfaces/interface/openconfig-if-ethernet:ethernet/state/counters/in-oversize-frames":
+		e = getCounters(entry, entry_backup, "SAI_PORT_STAT_ETHER_RX_OVERSIZE_PKTS", &eth_counter_val.InOversizeFrames)
+		return true, e
+	case "/openconfig-interfaces:interfaces/interface/ethernet/state/counters/in-undersize-frames",
+		"/openconfig-interfaces:interfaces/interface/openconfig-if-ethernet:ethernet/state/counters/in-undersize-frames":
+		e = getCounters(entry, entry_backup, "SAI_PORT_STAT_ETHER_STATS_UNDERSIZE_PKTS", &eth_counter_val.InUndersizeFrames)
+		return true, e
+	case "/openconfig-interfaces:interfaces/interface/ethernet/state/counters/in-jabber-frames",
+		"/openconfig-interfaces:interfaces/interface/openconfig-if-ethernet:ethernet/state/counters/in-jabber-frames":
+		e = getCounters(entry, entry_backup, "SAI_PORT_STAT_ETHER_STATS_JABBERS", &eth_counter_val.InJabberFrames)
+		return true, e
+	case "/openconfig-interfaces:interfaces/interface/ethernet/state/counters/in-fragment-frames",
+		"/openconfig-interfaces:interfaces/interface/openconfig-if-ethernet:ethernet/state/counters/in-fragment-frames":
+		e = getCounters(entry, entry_backup, "SAI_PORT_STAT_ETHER_STATS_FRAGMENTS", &eth_counter_val.InFragmentFrames)
+		return true, e
+	case "/openconfig-interfaces:interfaces/interface/openconfig-if-ethernet:ethernet/state/counters/openconfig-if-ethernet-ext:in-distribution/in-frames-64-octets":
+		ygot.BuildEmptyTree(eth_counter_val)
+		e = getCounters(entry, entry_backup, "SAI_PORT_STAT_ETHER_IN_PKTS_64_OCTETS", &eth_counter_val.InDistribution.InFrames_64Octets)
+		return true, e
+	case "/openconfig-interfaces:interfaces/interface/openconfig-if-ethernet:ethernet/state/counters/openconfig-if-ethernet-ext:in-distribution/in-frames-65-127-octets":
+		ygot.BuildEmptyTree(eth_counter_val)
+		e = getCounters(entry, entry_backup, "SAI_PORT_STAT_ETHER_IN_PKTS_65_TO_127_OCTETS", &eth_counter_val.InDistribution.InFrames_65_127Octets)
+		return true, e
+	case "/openconfig-interfaces:interfaces/interface/ethernet/state/counters/openconfig-if-ethernet-ext:in-distribution/in-frames-128-255-octets",
+		"/openconfig-interfaces:interfaces/interface/openconfig-if-ethernet:ethernet/state/counters/openconfig-if-ethernet-ext:in-distribution/in-frames-128-255-octets":
+		ygot.BuildEmptyTree(eth_counter_val)
+		e = getCounters(entry, entry_backup, "SAI_PORT_STAT_ETHER_IN_PKTS_128_TO_255_OCTETS", &eth_counter_val.InDistribution.InFrames_128_255Octets)
+		return true, e
+	case "/openconfig-interfaces:interfaces/interface/openconfig-if-ethernet:ethernet/state/counters/openconfig-if-ethernet-ext:in-distribution/in-frames-256-511-octets":
+		ygot.BuildEmptyTree(eth_counter_val)
+		e = getCounters(entry, entry_backup, "SAI_PORT_STAT_ETHER_IN_PKTS_256_TO_511_OCTETS", &eth_counter_val.InDistribution.InFrames_256_511Octets)
+		return true, e
+	case "/openconfig-interfaces:interfaces/interface/openconfig-if-ethernet:ethernet/state/counters/openconfig-if-ethernet-ext:in-distribution/in-frames-512-1023-octets":
+		ygot.BuildEmptyTree(eth_counter_val)
+		e = getCounters(entry, entry_backup, "SAI_PORT_STAT_ETHER_IN_PKTS_512_TO_1023_OCTETS", &eth_counter_val.InDistribution.InFrames_512_1023Octets)
+		return true, e
+	case "/openconfig-interfaces:interfaces/interface/openconfig-if-ethernet:ethernet/state/counters/openconfig-if-ethernet-ext:in-distribution/in-frames-1024-1518-octets":
+		ygot.BuildEmptyTree(eth_counter_val)
+		e = getCounters(entry, entry_backup, "SAI_PORT_STAT_ETHER_IN_PKTS_1024_TO_1518_OCTETS", &eth_counter_val.InDistribution.InFrames_1024_1518Octets)
+		return true, e
+
+	default:
+		log.Infof(targetUriPath + " - Not an interface state counter attribute")
+	}
+	return false, nil
+}
+
+var DbToYang_intf_get_counters_xfmr SubTreeXfmrDbToYang = func(inParams XfmrParams) error {
+	var err error
+
+	intfsObj := getIntfsRoot(inParams.ygRoot)
+	pathInfo := NewPathInfo(inParams.uri)
+	uriIfName := pathInfo.Var("name")
+	ifName := uriIfName
+
+	targetUriPath := pathInfo.YangPath
+	log.Info("targetUriPath is ", targetUriPath)
+
+	if !strings.Contains(targetUriPath, "/openconfig-interfaces:interfaces/interface/state/counters") {
+		log.Infof("%s is redundant", targetUriPath)
+		return err
+	}
+
+	intfType, _, ierr := getIntfTypeByName(ifName)
+	if intfType == IntfTypeUnset || ierr != nil {
+		log.Info("DbToYang_intf_get_counters_xfmr - Invalid interface type IntfTypeUnset")
+		return errors.New("Invalid interface type IntfTypeUnset")
+	}
+	intTbl := IntfTypeTblMap[intfType]
+	if intTbl.CountersHdl.PopulateCounters == nil {
+		log.Infof("Counters for Interface: %s not supported!", ifName)
+		return nil
+	}
+	var state_counters *ocbinds.OpenconfigInterfaces_Interfaces_Interface_State_Counters
+
+	if intfsObj != nil && intfsObj.Interface != nil && len(intfsObj.Interface) > 0 {
+		var ok bool = false
+		var intfObj *ocbinds.OpenconfigInterfaces_Interfaces_Interface
+		if intfObj, ok = intfsObj.Interface[uriIfName]; !ok {
+			intfObj, _ = intfsObj.NewInterface(uriIfName)
+			ygot.BuildEmptyTree(intfObj)
+		}
+		ygot.BuildEmptyTree(intfObj)
+		if intfObj.State == nil || intfObj.State.Counters == nil {
+			ygot.BuildEmptyTree(intfObj.State)
+		}
+		state_counters = intfObj.State.Counters
+	} else {
+		ygot.BuildEmptyTree(intfsObj)
+		intfObj, _ := intfsObj.NewInterface(uriIfName)
+		ygot.BuildEmptyTree(intfObj)
+		state_counters = intfObj.State.Counters
+	}
+
+	err = intTbl.CountersHdl.PopulateCounters(inParams, state_counters)
+	if log.V(3) {
+		log.Info("DbToYang_intf_get_counters_xfmr - ", state_counters)
+	}
+
+	return err
+}
+
+var populatePortCounters PopulateIntfCounters = func(inParams XfmrParams, counter interface{}) error {
+	var err error
+	pathInfo := NewPathInfo(inParams.uri)
+	ifName := pathInfo.Var("name")
+
+	targetUriPath := pathInfo.YangPath
+
+	if log.V(3) {
+		log.Info("PopulateIntfCounters : inParams.curDb : ", inParams.curDb, "D: ", inParams.d, "DB index : ", inParams.dbs[inParams.curDb])
+	}
+	oid, oiderr := getIntfCountersTblKey(inParams.dbs[inParams.curDb], ifName)
+	if oiderr != nil {
+		log.Info(oiderr)
+		return oiderr
+	}
+	cntTs := &db.TableSpec{Name: "COUNTERS"}
+	entry, dbErr := inParams.dbs[inParams.curDb].GetEntry(cntTs, db.Key{Comp: []string{oid}})
+	if dbErr != nil {
+		log.Info("PopulateIntfCounters : not able find the oid entry in DB Counters table")
+		return dbErr
+	}
+	CounterData := entry
+	cntTs_cp := &db.TableSpec{Name: "COUNTERS_BACKUP"}
+	entry_backup, dbErr := inParams.dbs[inParams.curDb].GetEntry(cntTs_cp, db.Key{Comp: []string{oid}})
+	if dbErr != nil {
+		m := make(map[string]string)
+		log.Info("PopulateIntfCounters : not able find the oid entry in DB COUNTERS_BACKUP table")
+		/* Frame backup data with 0 as counter values */
+		for attr := range entry.Field {
+			m[attr] = "0"
+		}
+		m["LAST_CLEAR_TIMESTAMP"] = "0"
+		entry_backup = db.Value{Field: m}
+	}
+	CounterBackUpData := entry_backup
+
+	switch targetUriPath {
+	case "/openconfig-interfaces:interfaces/interface/state/counters":
+		for _, attr := range portCntList {
+			uri := targetUriPath + "/" + attr
+			if ok, err := getSpecificCounterAttr(uri, &CounterData, &CounterBackUpData, counter); !ok || err != nil {
+				log.Info("Get Counter URI failed :", uri)
+				//err = errors.New("Get Counter URI failed")
+			}
+		}
+	case "/openconfig-interfaces:interfaces/interface/ethernet/state/counters",
+		"/openconfig-interfaces:interfaces/interface/openconfig-if-ethernet:ethernet/state/counters":
+		for _, attr := range etherCntList {
+			uri := targetUriPath + "/" + attr
+			if ok, err := getSpecificCounterAttr(uri, &CounterData, &CounterBackUpData, counter); !ok || err != nil {
+				log.Info("Get Ethernet Counter URI failed :", uri)
+				//err = errors.New("Get Ethernet Counter URI failed")
+			}
+		}
+		targetUriPath = "/openconfig-interfaces:interfaces/interface/openconfig-if-ethernet:ethernet/state/counters/openconfig-if-ethernet-ext:in-distribution"
+		fallthrough
+	case "/openconfig-interfaces:interfaces/interface/ethernet/state/counters/openconfig-if-ethernet-ext:in-distribution",
+		"/openconfig-interfaces:interfaces/interface/openconfig-if-ethernet:ethernet/state/counters/openconfig-if-ethernet-ext:in-distribution":
+		for _, attr := range etherCntInList {
+			uri := targetUriPath + "/" + attr
+			if ok, err := getSpecificCounterAttr(uri, &CounterData, &CounterBackUpData, counter); !ok || err != nil {
+				log.Info("Get Ethernet Counter URI failed :", uri)
+			}
+		}
+
+	default:
+		_, err = getSpecificCounterAttr(targetUriPath, &CounterData, &CounterBackUpData, counter)
+	}
+
+	return err
+}
+
+var YangToDb_intf_counters_key KeyXfmrYangToDb = func(inParams XfmrParams) (string, error) {
+	pathInfo := NewPathInfo(inParams.uri)
+	intfName := pathInfo.Var("name")
+	oid, oiderr := getIntfCountersTblKey(inParams.dbs[inParams.curDb], intfName)
+
+	return oid, oiderr
+}
+
+var DbToYang_intf_counters_key KeyXfmrDbToYang = func(inParams XfmrParams) (map[string]interface{}, error) {
+	rmap := make(map[string]interface{})
+	var err error
+	return rmap, err
+}
+
+var DbToYang_intf_get_ether_counters_xfmr SubTreeXfmrDbToYang = func(inParams XfmrParams) error {
+	var err error
+
+	intfsObj := getIntfsRoot(inParams.ygRoot)
+	pathInfo := NewPathInfo(inParams.uri)
+	uriIfName := pathInfo.Var("name")
+	ifName := uriIfName
+	log.Info("Ether counters subtree and ifname: ", ifName)
+
+	targetUriPath := pathInfo.YangPath
+	intfType, _, ierr := getIntfTypeByName(ifName)
+	if intfType == IntfTypeUnset || ierr != nil {
+		log.Info("DbToYang_intf_get_ether_counters_xfmr - Invalid interface type IntfTypeUnset")
+		return errors.New("Invalid interface type IntfTypeUnset")
+	}
+
+	if !strings.Contains(targetUriPath, "/openconfig-interfaces:interfaces/interface/ethernet/state/counters") &&
+		!strings.Contains(targetUriPath, "/openconfig-interfaces:interfaces/interface/openconfig-if-ethernet:ethernet/state/counters") {
+		log.Infof("%s is redundant", targetUriPath)
+		return err
+	}
+
+	var intfObj *ocbinds.OpenconfigInterfaces_Interfaces_Interface
+	var eth_counters *ocbinds.OpenconfigInterfaces_Interfaces_Interface_Ethernet_State_Counters
+
+	if intfsObj != nil && intfsObj.Interface != nil && len(intfsObj.Interface) > 0 {
+		var ok bool = false
+		if intfObj, ok = intfsObj.Interface[uriIfName]; !ok {
+			intfObj, _ = intfsObj.NewInterface(uriIfName)
+		}
+		ygot.BuildEmptyTree(intfObj)
+	} else {
+		ygot.BuildEmptyTree(intfsObj)
+		intfObj, _ = intfsObj.NewInterface(uriIfName)
+		ygot.BuildEmptyTree(intfObj)
+	}
+
+	ygot.BuildEmptyTree(intfObj.Ethernet)
+	ygot.BuildEmptyTree(intfObj.Ethernet.State)
+	ygot.BuildEmptyTree(intfObj.Ethernet.State.Counters)
+	eth_counters = intfObj.Ethernet.State.Counters
+
+	return populatePortCounters(inParams, eth_counters)
 }
 
 var intf_post_xfmr PostXfmrFunc = func(inParams XfmrParams) (map[string]map[string]db.Value, error) {

--- a/translib/transformer/xfmr_intf.go
+++ b/translib/transformer/xfmr_intf.go
@@ -51,11 +51,7 @@ func init() {
 	XlateFuncBind("DbToYang_intf_eth_port_speed_xfmr", DbToYang_intf_eth_port_speed_xfmr)
 
 	XlateFuncBind("DbToYang_intf_get_counters_xfmr", DbToYang_intf_get_counters_xfmr)
-	//XlateFuncBind("Subscribe_intf_get_counters_xfmr", Subscribe_intf_get_counters_xfmr)
-	//XlateFuncBind("DbToYangPath_intf_get_counters_path_xfmr", DbToYangPath_intf_get_counters_path_xfmr)
-
 	XlateFuncBind("DbToYang_intf_get_ether_counters_xfmr", DbToYang_intf_get_ether_counters_xfmr)
-	//XlateFuncBind("Subscribe_intf_get_ether_counters_xfmr", Subscribe_intf_get_ether_counters_xfmr)
 
 	XlateFuncBind("YangToDb_intf_subintfs_xfmr", YangToDb_intf_subintfs_xfmr)
 	XlateFuncBind("DbToYang_intf_subintfs_xfmr", DbToYang_intf_subintfs_xfmr)
@@ -885,7 +881,7 @@ func getIntfCountersTblKey(d *db.DB, ifKey string) (string, error) {
 	return oid, err
 }
 
-func getCounters(entry *db.Value, entry_backup *db.Value, attr string, counter_val **uint64) error {
+func getCounters(entry *db.Value, attr string, counter_val **uint64) error {
 
 	var ok bool = false
 	var err error
@@ -893,16 +889,10 @@ func getCounters(entry *db.Value, entry_backup *db.Value, attr string, counter_v
 	if !ok {
 		return errors.New("Attr " + attr + "doesn't exist in IF table Map!")
 	}
-	val2, ok := entry_backup.Field[attr]
-	if !ok {
-		return errors.New("Attr " + attr + "doesn't exist in IF backup table Map!")
-	}
 
 	if len(val1) > 0 {
 		v, _ := strconv.ParseUint(val1, 10, 64)
-		v_backup, _ := strconv.ParseUint(val2, 10, 64)
-		val := v - v_backup
-		*counter_val = &val
+		*counter_val = &v
 		return nil
 	}
 	return err
@@ -916,7 +906,7 @@ var etherCntList []string = []string{"in-oversize-frames", "in-undersize-frames"
 var etherCntInList []string = []string{"in-frames-64-octets", "in-frames-65-127-octets", "in-frames-128-255-octets",
 	"in-frames-256-511-octets", "in-frames-512-1023-octets", "in-frames-1024-1518-octets"}
 
-func getSpecificCounterAttr(targetUriPath string, entry *db.Value, entry_backup *db.Value, counter interface{}) (bool, error) {
+func getSpecificCounterAttr(targetUriPath string, entry *db.Value, counter interface{}) (bool, error) {
 
 	var e error
 	var counter_val *ocbinds.OpenconfigInterfaces_Interfaces_Interface_State_Counters
@@ -930,36 +920,36 @@ func getSpecificCounterAttr(targetUriPath string, entry *db.Value, entry_backup 
 
 	switch targetUriPath {
 	case "/openconfig-interfaces:interfaces/interface/state/counters/in-octets":
-		e = getCounters(entry, entry_backup, "SAI_PORT_STAT_IF_IN_OCTETS", &counter_val.InOctets)
+		e = getCounters(entry, "SAI_PORT_STAT_IF_IN_OCTETS", &counter_val.InOctets)
 		return true, e
 
 	case "/openconfig-interfaces:interfaces/interface/state/counters/in-unicast-pkts":
-		e = getCounters(entry, entry_backup, "SAI_PORT_STAT_IF_IN_UCAST_PKTS", &counter_val.InUnicastPkts)
+		e = getCounters(entry, "SAI_PORT_STAT_IF_IN_UCAST_PKTS", &counter_val.InUnicastPkts)
 		return true, e
 
 	case "/openconfig-interfaces:interfaces/interface/state/counters/in-broadcast-pkts":
-		e = getCounters(entry, entry_backup, "SAI_PORT_STAT_IF_IN_BROADCAST_PKTS", &counter_val.InBroadcastPkts)
+		e = getCounters(entry, "SAI_PORT_STAT_IF_IN_BROADCAST_PKTS", &counter_val.InBroadcastPkts)
 		return true, e
 
 	case "/openconfig-interfaces:interfaces/interface/state/counters/in-multicast-pkts":
-		e = getCounters(entry, entry_backup, "SAI_PORT_STAT_IF_IN_MULTICAST_PKTS", &counter_val.InMulticastPkts)
+		e = getCounters(entry, "SAI_PORT_STAT_IF_IN_MULTICAST_PKTS", &counter_val.InMulticastPkts)
 		return true, e
 
 	case "/openconfig-interfaces:interfaces/interface/state/counters/in-errors":
-		e = getCounters(entry, entry_backup, "SAI_PORT_STAT_IF_IN_ERRORS", &counter_val.InErrors)
+		e = getCounters(entry, "SAI_PORT_STAT_IF_IN_ERRORS", &counter_val.InErrors)
 		return true, e
 
 	case "/openconfig-interfaces:interfaces/interface/state/counters/in-discards":
-		e = getCounters(entry, entry_backup, "SAI_PORT_STAT_IF_IN_DISCARDS", &counter_val.InDiscards)
+		e = getCounters(entry, "SAI_PORT_STAT_IF_IN_DISCARDS", &counter_val.InDiscards)
 		return true, e
 
 	case "/openconfig-interfaces:interfaces/interface/state/counters/in-pkts":
 		var inNonUCastPkt, inUCastPkt *uint64
 		var in_pkts uint64
 
-		e = getCounters(entry, entry_backup, "SAI_PORT_STAT_IF_IN_NON_UCAST_PKTS", &inNonUCastPkt)
+		e = getCounters(entry, "SAI_PORT_STAT_IF_IN_NON_UCAST_PKTS", &inNonUCastPkt)
 		if e == nil {
-			e = getCounters(entry, entry_backup, "SAI_PORT_STAT_IF_IN_UCAST_PKTS", &inUCastPkt)
+			e = getCounters(entry, "SAI_PORT_STAT_IF_IN_UCAST_PKTS", &inUCastPkt)
 			if e != nil {
 				return true, e
 			}
@@ -971,42 +961,36 @@ func getSpecificCounterAttr(targetUriPath string, entry *db.Value, entry_backup 
 		}
 
 	case "/openconfig-interfaces:interfaces/interface/state/counters/out-octets":
-		e = getCounters(entry, entry_backup, "SAI_PORT_STAT_IF_OUT_OCTETS", &counter_val.OutOctets)
+		e = getCounters(entry, "SAI_PORT_STAT_IF_OUT_OCTETS", &counter_val.OutOctets)
 		return true, e
 
 	case "/openconfig-interfaces:interfaces/interface/state/counters/out-unicast-pkts":
-		e = getCounters(entry, entry_backup, "SAI_PORT_STAT_IF_OUT_UCAST_PKTS", &counter_val.OutUnicastPkts)
+		e = getCounters(entry, "SAI_PORT_STAT_IF_OUT_UCAST_PKTS", &counter_val.OutUnicastPkts)
 		return true, e
 
 	case "/openconfig-interfaces:interfaces/interface/state/counters/out-broadcast-pkts":
-		e = getCounters(entry, entry_backup, "SAI_PORT_STAT_IF_OUT_BROADCAST_PKTS", &counter_val.OutBroadcastPkts)
+		e = getCounters(entry, "SAI_PORT_STAT_IF_OUT_BROADCAST_PKTS", &counter_val.OutBroadcastPkts)
 		return true, e
 
 	case "/openconfig-interfaces:interfaces/interface/state/counters/out-multicast-pkts":
-		e = getCounters(entry, entry_backup, "SAI_PORT_STAT_IF_OUT_MULTICAST_PKTS", &counter_val.OutMulticastPkts)
+		e = getCounters(entry, "SAI_PORT_STAT_IF_OUT_MULTICAST_PKTS", &counter_val.OutMulticastPkts)
 		return true, e
 
 	case "/openconfig-interfaces:interfaces/interface/state/counters/out-errors":
-		e = getCounters(entry, entry_backup, "SAI_PORT_STAT_IF_OUT_ERRORS", &counter_val.OutErrors)
+		e = getCounters(entry, "SAI_PORT_STAT_IF_OUT_ERRORS", &counter_val.OutErrors)
 		return true, e
 
 	case "/openconfig-interfaces:interfaces/interface/state/counters/out-discards":
-		e = getCounters(entry, entry_backup, "SAI_PORT_STAT_IF_OUT_DISCARDS", &counter_val.OutDiscards)
+		e = getCounters(entry, "SAI_PORT_STAT_IF_OUT_DISCARDS", &counter_val.OutDiscards)
 		return true, e
 
-	//case "/openconfig-interfaces:interfaces/interface/state/counters/last-clear":
-	//	timestampStr := (entry_backup.Field["LAST_CLEAR_TIMESTAMP"])
-	//	timestamp, _ := strconv.ParseUint(timestampStr, 10, 64)
-	//	counter_val.LastClear = &timestamp
-	//	return true, e
-	//
 	case "/openconfig-interfaces:interfaces/interface/state/counters/out-pkts":
 		var outNonUCastPkt, outUCastPkt *uint64
 		var out_pkts uint64
 
-		e = getCounters(entry, entry_backup, "SAI_PORT_STAT_IF_OUT_NON_UCAST_PKTS", &outNonUCastPkt)
+		e = getCounters(entry, "SAI_PORT_STAT_IF_OUT_NON_UCAST_PKTS", &outNonUCastPkt)
 		if e == nil {
-			e = getCounters(entry, entry_backup, "SAI_PORT_STAT_IF_OUT_UCAST_PKTS", &outUCastPkt)
+			e = getCounters(entry, "SAI_PORT_STAT_IF_OUT_UCAST_PKTS", &outUCastPkt)
 			if e != nil {
 				return true, e
 			}
@@ -1019,44 +1003,44 @@ func getSpecificCounterAttr(targetUriPath string, entry *db.Value, entry_backup 
 
 	case "/openconfig-interfaces:interfaces/interface/ethernet/state/counters/in-oversize-frames",
 		"/openconfig-interfaces:interfaces/interface/openconfig-if-ethernet:ethernet/state/counters/in-oversize-frames":
-		e = getCounters(entry, entry_backup, "SAI_PORT_STAT_ETHER_RX_OVERSIZE_PKTS", &eth_counter_val.InOversizeFrames)
+		e = getCounters(entry, "SAI_PORT_STAT_ETHER_RX_OVERSIZE_PKTS", &eth_counter_val.InOversizeFrames)
 		return true, e
 	case "/openconfig-interfaces:interfaces/interface/ethernet/state/counters/in-undersize-frames",
 		"/openconfig-interfaces:interfaces/interface/openconfig-if-ethernet:ethernet/state/counters/in-undersize-frames":
-		e = getCounters(entry, entry_backup, "SAI_PORT_STAT_ETHER_STATS_UNDERSIZE_PKTS", &eth_counter_val.InUndersizeFrames)
+		e = getCounters(entry, "SAI_PORT_STAT_ETHER_STATS_UNDERSIZE_PKTS", &eth_counter_val.InUndersizeFrames)
 		return true, e
 	case "/openconfig-interfaces:interfaces/interface/ethernet/state/counters/in-jabber-frames",
 		"/openconfig-interfaces:interfaces/interface/openconfig-if-ethernet:ethernet/state/counters/in-jabber-frames":
-		e = getCounters(entry, entry_backup, "SAI_PORT_STAT_ETHER_STATS_JABBERS", &eth_counter_val.InJabberFrames)
+		e = getCounters(entry, "SAI_PORT_STAT_ETHER_STATS_JABBERS", &eth_counter_val.InJabberFrames)
 		return true, e
 	case "/openconfig-interfaces:interfaces/interface/ethernet/state/counters/in-fragment-frames",
 		"/openconfig-interfaces:interfaces/interface/openconfig-if-ethernet:ethernet/state/counters/in-fragment-frames":
-		e = getCounters(entry, entry_backup, "SAI_PORT_STAT_ETHER_STATS_FRAGMENTS", &eth_counter_val.InFragmentFrames)
+		e = getCounters(entry, "SAI_PORT_STAT_ETHER_STATS_FRAGMENTS", &eth_counter_val.InFragmentFrames)
 		return true, e
 	case "/openconfig-interfaces:interfaces/interface/openconfig-if-ethernet:ethernet/state/counters/openconfig-if-ethernet-ext:in-distribution/in-frames-64-octets":
 		ygot.BuildEmptyTree(eth_counter_val)
-		e = getCounters(entry, entry_backup, "SAI_PORT_STAT_ETHER_IN_PKTS_64_OCTETS", &eth_counter_val.InDistribution.InFrames_64Octets)
+		e = getCounters(entry, "SAI_PORT_STAT_ETHER_IN_PKTS_64_OCTETS", &eth_counter_val.InDistribution.InFrames_64Octets)
 		return true, e
 	case "/openconfig-interfaces:interfaces/interface/openconfig-if-ethernet:ethernet/state/counters/openconfig-if-ethernet-ext:in-distribution/in-frames-65-127-octets":
 		ygot.BuildEmptyTree(eth_counter_val)
-		e = getCounters(entry, entry_backup, "SAI_PORT_STAT_ETHER_IN_PKTS_65_TO_127_OCTETS", &eth_counter_val.InDistribution.InFrames_65_127Octets)
+		e = getCounters(entry, "SAI_PORT_STAT_ETHER_IN_PKTS_65_TO_127_OCTETS", &eth_counter_val.InDistribution.InFrames_65_127Octets)
 		return true, e
 	case "/openconfig-interfaces:interfaces/interface/ethernet/state/counters/openconfig-if-ethernet-ext:in-distribution/in-frames-128-255-octets",
 		"/openconfig-interfaces:interfaces/interface/openconfig-if-ethernet:ethernet/state/counters/openconfig-if-ethernet-ext:in-distribution/in-frames-128-255-octets":
 		ygot.BuildEmptyTree(eth_counter_val)
-		e = getCounters(entry, entry_backup, "SAI_PORT_STAT_ETHER_IN_PKTS_128_TO_255_OCTETS", &eth_counter_val.InDistribution.InFrames_128_255Octets)
+		e = getCounters(entry, "SAI_PORT_STAT_ETHER_IN_PKTS_128_TO_255_OCTETS", &eth_counter_val.InDistribution.InFrames_128_255Octets)
 		return true, e
 	case "/openconfig-interfaces:interfaces/interface/openconfig-if-ethernet:ethernet/state/counters/openconfig-if-ethernet-ext:in-distribution/in-frames-256-511-octets":
 		ygot.BuildEmptyTree(eth_counter_val)
-		e = getCounters(entry, entry_backup, "SAI_PORT_STAT_ETHER_IN_PKTS_256_TO_511_OCTETS", &eth_counter_val.InDistribution.InFrames_256_511Octets)
+		e = getCounters(entry, "SAI_PORT_STAT_ETHER_IN_PKTS_256_TO_511_OCTETS", &eth_counter_val.InDistribution.InFrames_256_511Octets)
 		return true, e
 	case "/openconfig-interfaces:interfaces/interface/openconfig-if-ethernet:ethernet/state/counters/openconfig-if-ethernet-ext:in-distribution/in-frames-512-1023-octets":
 		ygot.BuildEmptyTree(eth_counter_val)
-		e = getCounters(entry, entry_backup, "SAI_PORT_STAT_ETHER_IN_PKTS_512_TO_1023_OCTETS", &eth_counter_val.InDistribution.InFrames_512_1023Octets)
+		e = getCounters(entry, "SAI_PORT_STAT_ETHER_IN_PKTS_512_TO_1023_OCTETS", &eth_counter_val.InDistribution.InFrames_512_1023Octets)
 		return true, e
 	case "/openconfig-interfaces:interfaces/interface/openconfig-if-ethernet:ethernet/state/counters/openconfig-if-ethernet-ext:in-distribution/in-frames-1024-1518-octets":
 		ygot.BuildEmptyTree(eth_counter_val)
-		e = getCounters(entry, entry_backup, "SAI_PORT_STAT_ETHER_IN_PKTS_1024_TO_1518_OCTETS", &eth_counter_val.InDistribution.InFrames_1024_1518Octets)
+		e = getCounters(entry, "SAI_PORT_STAT_ETHER_IN_PKTS_1024_TO_1518_OCTETS", &eth_counter_val.InDistribution.InFrames_1024_1518Octets)
 		return true, e
 
 	default:
@@ -1142,25 +1126,12 @@ var populatePortCounters PopulateIntfCounters = func(inParams XfmrParams, counte
 		return dbErr
 	}
 	CounterData := entry
-	cntTs_cp := &db.TableSpec{Name: "COUNTERS_BACKUP"}
-	entry_backup, dbErr := inParams.dbs[inParams.curDb].GetEntry(cntTs_cp, db.Key{Comp: []string{oid}})
-	if dbErr != nil {
-		m := make(map[string]string)
-		log.Info("PopulateIntfCounters : not able find the oid entry in DB COUNTERS_BACKUP table")
-		/* Frame backup data with 0 as counter values */
-		for attr := range entry.Field {
-			m[attr] = "0"
-		}
-		m["LAST_CLEAR_TIMESTAMP"] = "0"
-		entry_backup = db.Value{Field: m}
-	}
-	CounterBackUpData := entry_backup
 
 	switch targetUriPath {
 	case "/openconfig-interfaces:interfaces/interface/state/counters":
 		for _, attr := range portCntList {
 			uri := targetUriPath + "/" + attr
-			if ok, err := getSpecificCounterAttr(uri, &CounterData, &CounterBackUpData, counter); !ok || err != nil {
+			if ok, err := getSpecificCounterAttr(uri, &CounterData, counter); !ok || err != nil {
 				log.Info("Get Counter URI failed :", uri)
 				//err = errors.New("Get Counter URI failed")
 			}
@@ -1169,7 +1140,7 @@ var populatePortCounters PopulateIntfCounters = func(inParams XfmrParams, counte
 		"/openconfig-interfaces:interfaces/interface/openconfig-if-ethernet:ethernet/state/counters":
 		for _, attr := range etherCntList {
 			uri := targetUriPath + "/" + attr
-			if ok, err := getSpecificCounterAttr(uri, &CounterData, &CounterBackUpData, counter); !ok || err != nil {
+			if ok, err := getSpecificCounterAttr(uri, &CounterData, counter); !ok || err != nil {
 				log.Info("Get Ethernet Counter URI failed :", uri)
 				//err = errors.New("Get Ethernet Counter URI failed")
 			}
@@ -1180,13 +1151,13 @@ var populatePortCounters PopulateIntfCounters = func(inParams XfmrParams, counte
 		"/openconfig-interfaces:interfaces/interface/openconfig-if-ethernet:ethernet/state/counters/openconfig-if-ethernet-ext:in-distribution":
 		for _, attr := range etherCntInList {
 			uri := targetUriPath + "/" + attr
-			if ok, err := getSpecificCounterAttr(uri, &CounterData, &CounterBackUpData, counter); !ok || err != nil {
+			if ok, err := getSpecificCounterAttr(uri, &CounterData, counter); !ok || err != nil {
 				log.Info("Get Ethernet Counter URI failed :", uri)
 			}
 		}
 
 	default:
-		_, err = getSpecificCounterAttr(targetUriPath, &CounterData, &CounterBackUpData, counter)
+		_, err = getSpecificCounterAttr(targetUriPath, &CounterData, counter)
 	}
 
 	return err


### PR DESCRIPTION
Support for Interface and Ethernet counters. 
This should address the pipeline test error that is caused by missing path. 
Check: https://dev.azure.com/mssonic/build/_build/results?buildId=535436&view=logs&j=406f67d9-8952-5074-7a53-dcb346cb6a5f&t=0fec046d-cdc9-520d-53e1-2d2c0b260e54&l=1656
 
Fail on UT-log are for tests that leave out ipv4-state as pipelines do not have APPL_DB while local switches do.
[UT_run.log](https://github.com/nagarwal03/oc-yang-intf/files/15268471/UT_run.log)
[translib_run.log](https://github.com/nagarwal03/oc-yang-intf/files/15268473/translib_run.log)

[manual_GET_interface.log](https://github.com/nagarwal03/oc-yang-intf/files/15268474/manual_GET_interface.log)
[manual_GET_interface_ethernet.log](https://github.com/nagarwal03/oc-yang-intf/files/15268475/manual_GET_interface_ethernet.log)

Ethernet257 has a switch connected to it, and will have non-0 values.
Fail on on-change is because these attributes has on-change disabled in deviation. 
[on_change_subscription.log](https://github.com/nagarwal03/oc-yang-intf/files/15268476/on_change_subscription.log)
[target_defined_subscription.log](https://github.com/nagarwal03/oc-yang-intf/files/15268477/target_defined_subscription.log)
[sample_subscription.log](https://github.com/nagarwal03/oc-yang-intf/files/15268478/sample_subscription.log)
